### PR TITLE
Tiny bug fix: make (detect-python) ask correctly for header files

### DIFF
--- a/grovel-include-dir.lisp
+++ b/grovel-include-dir.lisp
@@ -27,16 +27,17 @@
                         (or
                          (probe-file (merge-pathnames "miniconda3/" (user-homedir-pathname)))
                          (probe-file "/usr/local/miniconda3/")))))
-          (loop :for minor :from 7 :downto 4
-             :for it := (cl-fad:directory-exists-p (merge-pathnames (format nil "include/python3.~dm/" minor) path))
-             :when it
-             :return (progn
-                       (setf *cpython-lib* (cl:list
-                                            (or (probe-file (merge-pathnames
-                                                             (format nil "lib/libpython3.~Am.so.1.0" minor) path))
-                                                (probe-file (merge-pathnames
-                                                             (format nil "lib/libpython3.~Am.dylib" minor) path)))))
-                       it))))
+          (when path
+            (loop :for minor :from 7 :downto 4
+                  :for it := (cl-fad:directory-exists-p (merge-pathnames (format nil "include/python3.~dm/" minor) path))
+                  :when it
+                  :return (progn
+                            (setf *cpython-lib* (cl:list
+                                                 (or (probe-file (merge-pathnames
+                                                                  (format nil "lib/libpython3.~Am.so.1.0" minor) path))
+                                                     (probe-file (merge-pathnames
+                                                                  (format nil "lib/libpython3.~Am.dylib" minor) path)))))
+                            it)))))
       (loop :for minor :from 7 :downto 4
          :when (or (cl-fad:directory-exists-p (format nil "/usr/include/python3.~d" minor))
                    (cl-fad:directory-exists-p (format nil "/usr/local/include/python3.~d" minor)))


### PR DESCRIPTION
Tiny bug fix: make (detect-python) ask correctly for the location of Python header files.

Previously, when it wasn't located, it didn't ask for the location, and instead it failed with an error that might confuse the user, due to trying to merge pathname with NIL. This might make the user think that the library is at fault.

