### PR TITLE
use python3-config command to find library and include paths

### DIFF
--- a/burgled-batteries3.asd
+++ b/burgled-batteries3.asd
@@ -32,6 +32,7 @@ in #p\"grovel-include-dir.lisp\".
     :serial t
     :components
     ((:file "packages")
+     (:file "config")
      #-burgled-batteries3.guess-not-grovel (:file "grovel-include-dir")
      #-burgled-batteries3.guess-not-grovel (cffi-grovel:grovel-file "grovel")
      #+burgled-batteries3.guess-not-grovel (:file "grovel-guess")

--- a/config.lisp
+++ b/config.lisp
@@ -1,0 +1,21 @@
+(in-package #:cpython3)
+
+;;;; Utilities for extracting configuration information from the `python3-config` command line tool
+;; Inspired by and templated from GSL-CONFIG in GSLL 
+(defun python3-config (arg &optional path-opt)
+  "A wrapper for tool `python3-config'."
+  (or
+   (ignore-errors
+     (let ((output (with-input-from-string
+                       (s (with-output-to-string (asdf::*verbose-out*)
+                            (uiop:run-program `("python3-config" ,arg) :output asdf::*verbose-out*)))
+                     (read-line s)))
+           (len (length path-opt)))
+       (if (null path-opt)
+         output
+         (when (eql len (mismatch output path-opt :test #'string=))
+           (uiop:ensure-directory-pathname
+	    (uiop:ensure-absolute-pathname
+	     (pathname
+	      (subseq output len (position #\space output)))))))))
+   (warn "Error attempting to run the `python3-config` command")))

--- a/grovel-include-dir.lisp
+++ b/grovel-include-dir.lisp
@@ -55,6 +55,7 @@
       ;; still allowing for a change in Python version
       (when (boundp '*cpython-include-dir*)
         (cl-fad:directory-exists-p *cpython-include-dir*))
+      (python3-config "--include" "-I")
       (query-user-for-include-dir)))
 
 (defparameter *cpython-include-dir* (detect-python))


### PR DESCRIPTION
On OSX, the include path and library paths for python3 can vary quite widely depending upon how python3 was installed.  However, the `python3-config` command can be used to query these locations.  

This pull requests adds code to use `python3-config` to automatically discover these paths without needing to query the user:
1. For library paths on OSX only
2. For include paths if everything else other than querying the user fails
